### PR TITLE
BUG: Add safeguards against `sender.BCT` being unitialized

### DIFF
--- a/extension/bct.js
+++ b/extension/bct.js
@@ -349,10 +349,12 @@ async function runBCT(){
 								if(message.replyRequested)	sendBctInitilization(false);
 								break;
 							case BCT_MSG_ACTIVITY_AROUSAL_SYNC:
+								if (!sender.BCT) break;
 								sender.BCT.splitOrgasmArousal.arousalProgress = message.bctArousalProgress;
 								sender.BCT.splitOrgasmArousal.ProgressTimer = message.bctProgressTimer;
 								break;
 							case BCT_MSG_SETTINGS_SYNC:
+								if (!sender.BCT) break;
 								sender.BCT.bctSettings = message.bctSettings;
 								AddRelationDialog(sender);
 								break;


### PR DESCRIPTION
Partially addresses https://github.com/agicitag/BCTweaks/issues/41

Adds a check to a few `parseMessage` branches that verifies whether the sending characters BCT settings are actually defined. This PR does not address the as of yet unidentified root cause of the issue (_i.e._ why the likes of `BCT_MSG_ACTIVITY_AROUSAL_SYNC` are received before `BCT_MSG_INITILIZATION_SYNC`), but it does prevent the console log from being spammed with "TypeError: sender.BCT is undefined" messages on a semi-regular basis.
