### PR TITLE
MAINT: Preserve the relationship icon when showing the "Add as BF" prompt in R107

### DIFF
--- a/extension/bct.js
+++ b/extension/bct.js
@@ -2090,18 +2090,19 @@ Input should be comma separated Member IDs. (Maximum 30 members)`
 					&& !(Player.Ownership != null && Player.Ownership.MemberNumber === member)
 					&& !(Player.Lovership.some(lover => lover.MemberNumber == member))) {
 							let BFelement = htmlDoc.getElementsByClassName("friend-list-column RelationType")[i];
-							BFelement.innerHTML = "Best Friend";
+							const BFelementText = Array.from(BFelement.childNodes).find(e => e.nodeType === Node.TEXT_NODE);
+							BFelementText.textContent = "Best Friend";
 							BFelement.style.cursor = "pointer";
 							BFelement.style.textDecoration = "underline";
 							BFelement.style.color = "lime";
 							let  onHoverBF = () => {
-								BFelement.innerHTML = "Delete BF?";
+								BFelementText.textContent = "Delete BF?";
 							}
 							let onOutBF = () => {
-								BFelement.innerHTML = "Best Friend";
+								BFelementText.textContent = "Best Friend";
 							}
 							let onClickBF = () => {
-								BFelement.innerHTML = "Deleted";
+								BFelementText.textContent = "Deleted";
 								RemoveFromBFList(member);
 								BFelement.removeEventListener("mouseover",onHoverBF);
 								BFelement.removeEventListener("mouseout",onOutBF);
@@ -2113,19 +2114,20 @@ Input should be comma separated Member IDs. (Maximum 30 members)`
 					else if (!(Player.Ownership != null && Player.Ownership.MemberNumber === member)
 					&& !(Player.Lovership.some(lover => lover.MemberNumber == member))){
 							let NonBFelement = htmlDoc.getElementsByClassName("friend-list-column RelationType")[i];
+							const NonBFelementText = Array.from(NonBFelement.childNodes).find(e => e.nodeType === Node.TEXT_NODE);
 							NonBFelement.style.cursor = "pointer";
 							let forUndo = "";
 							let  onHoverBF = () => {
-								forUndo = NonBFelement.innerHTML;
-								NonBFelement.innerHTML = "Add as BF?";
+								forUndo = NonBFelementText.textContent;
+								NonBFelementText.textContent = "Add as BF?";
 								NonBFelement.style.textDecoration = "underline";
 							}
 							let onOutBF = () => {
-								NonBFelement.innerHTML = forUndo;
+								NonBFelementText.textContent = forUndo;
 								NonBFelement.style.textDecoration = "";
 							}
 							let onClickBF = () => {
-								NonBFelement.innerHTML = "Added";
+								NonBFelementText.textContent = "Added";
 								AddToBFList(member);
 								NonBFelement.removeEventListener("mouseover",onHoverBF);
 								NonBFelement.removeEventListener("mouseout",onOutBF);

--- a/extension/bct.js
+++ b/extension/bct.js
@@ -2104,10 +2104,10 @@ Input should be comma separated Member IDs. (Maximum 30 members)`
 							let onClickBF = () => {
 								BFelementText.textContent = "Deleted";
 								RemoveFromBFList(member);
-								BFelement.removeEventListener("mouseover",onHoverBF);
+								BFelement.removeEventListener("mouseenter",onHoverBF);
 								BFelement.removeEventListener("mouseleave",onOutBF);
 							}
-							BFelement.addEventListener("mouseover", onHoverBF);
+							BFelement.addEventListener("mouseenter", onHoverBF);
 							BFelement.addEventListener("mouseleave", onOutBF);
 							BFelement.addEventListener("click",onClickBF);
 					}
@@ -2129,10 +2129,10 @@ Input should be comma separated Member IDs. (Maximum 30 members)`
 							let onClickBF = () => {
 								NonBFelementText.textContent = "Added";
 								AddToBFList(member);
-								NonBFelement.removeEventListener("mouseover",onHoverBF);
+								NonBFelement.removeEventListener("mouseenter",onHoverBF);
 								NonBFelement.removeEventListener("mouseleave",onOutBF);
 							}
-							NonBFelement.addEventListener("mouseover", onHoverBF);
+							NonBFelement.addEventListener("mouseenter", onHoverBF);
 							NonBFelement.addEventListener("mouseleave", onOutBF);
 							NonBFelement.addEventListener("click",onClickBF);
 					}

--- a/extension/bct.js
+++ b/extension/bct.js
@@ -2105,10 +2105,10 @@ Input should be comma separated Member IDs. (Maximum 30 members)`
 								BFelementText.textContent = "Deleted";
 								RemoveFromBFList(member);
 								BFelement.removeEventListener("mouseover",onHoverBF);
-								BFelement.removeEventListener("mouseout",onOutBF);
+								BFelement.removeEventListener("mouseleave",onOutBF);
 							}
 							BFelement.addEventListener("mouseover", onHoverBF);
-							BFelement.addEventListener("mouseout", onOutBF);
+							BFelement.addEventListener("mouseleave", onOutBF);
 							BFelement.addEventListener("click",onClickBF);
 					}
 					else if (!(Player.Ownership != null && Player.Ownership.MemberNumber === member)
@@ -2130,10 +2130,10 @@ Input should be comma separated Member IDs. (Maximum 30 members)`
 								NonBFelementText.textContent = "Added";
 								AddToBFList(member);
 								NonBFelement.removeEventListener("mouseover",onHoverBF);
-								NonBFelement.removeEventListener("mouseout",onOutBF);
+								NonBFelement.removeEventListener("mouseleave",onOutBF);
 							}
 							NonBFelement.addEventListener("mouseover", onHoverBF);
-							NonBFelement.addEventListener("mouseout", onOutBF);
+							NonBFelement.addEventListener("mouseleave", onOutBF);
 							NonBFelement.addEventListener("click",onClickBF);
 					}
 				}


### PR DESCRIPTION
This PR ensures that the "Add as BF" prompt does not erase any of the relationship icons when displaying the "Add as BF" prompt and the likes.

This has two advantages:
* The icons look pretty neat, so hiding them is a bit of a waste
* Hiding the icons messes with row-spacing, which looks rather jarring as the UI constantly shifts around when triggering hover events

Examples
---------
![bct](https://github.com/user-attachments/assets/d60cbf6f-45a0-4c7b-9b6a-7a403ebf035a)
