### PR TITLE
MAINT: Adapt to the R111 dialog `item` mode rework

### DIFF
--- a/extension/bct.js
+++ b/extension/bct.js
@@ -2663,10 +2663,47 @@ const replaceResponseEnd = `ChatSearchAutoJoinRoom(); }`
 			args[0] = IMAGES.BEST_FRIEND_TIMER_LOCK;
 		}
 		next(args);
-	})
+	});
+
+	if (GameVersion !== "R110") { // R111
+		function updateBctIconUrl(button) {
+			button.querySelectorAll("img.button-icon[src*='Best Friend']").forEach(img => {
+				if (img.src.includes(BF_TIMER_LOCK_NAME.replaceAll(" ", "%20"))) {
+					img.src = IMAGES.BEST_FRIEND_TIMER_LOCK;
+				} else if (img.src.includes(BF_LOCK_NAME.replaceAll(" ", "%20"))) {
+					img.src = IMAGES.BEST_FRIEND_LOCK;
+				}
+			});
+
+			button.querySelectorAll(".button-icon-tooltip-li[style*='Best Friend']").forEach(elem => {
+				if (elem.style.backgroundImage.includes(BF_TIMER_LOCK_NAME)) {
+					elem.style.backgroundImage = `url(${IMAGES.BEST_FRIEND_TIMER_LOCK})`;
+				} else if (elem.style.backgroundImage.includes(BF_LOCK_NAME)) {
+					elem.style.backgroundImage = `url(${IMAGES.BEST_FRIEND_LOCK})`;
+				}
+			});
+		}
+
+		modAPI.hookFunction("ElementButton.CreateForAsset", 0, (args, next) => {
+			args[4] ??= {};
+			const asset = "Asset" in args[1] ? args[1].Asset : args[1];
+			switch (asset.Name) {
+				case BF_LOCK_NAME:
+					args[4].image = IMAGES.BEST_FRIEND_LOCK;
+					break;
+				case BF_TIMER_LOCK_NAME:
+					args[4].image = IMAGES.BEST_FRIEND_TIMER_LOCK;
+					break;
+			}
+
+			const button = next(args);
+			updateBctIconUrl(button);
+			return button;
+		});
+	}
 
 	// Preview Lock Icon for BF locks
-	{
+	if (GameVersion === "R110") {
 		const replace = `if (InventoryItemHasEffect(item, "Lock")) {`;
 		const replaceBy = `if (InventoryItemHasEffect(item, "Lock")) {
 			if (item.Property && item.Property.Name === "${BF_LOCK_NAME}") {


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5278](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5278)

Above-mentioned PR overhauls the UI of a number of dialog menu modes (including the `item` mode) for R111, switching from a canvas- to DOM-based UI. Consequently, custom items will now have to hook into `ElementButton.CreateForAsset()` in order to set their custom button images, a change which is thus introduced herein.

Includes changes both suitable for the beta-period and full R111 release.
